### PR TITLE
Add Migrations

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -15,10 +15,12 @@ class CreateUsersTable extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->bigIncrements('id');
+            $table->enum('type', ['', 'admin']);
             $table->string('name');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
+            $table->string('api_key', 255);
             $table->rememberToken();
             $table->timestamps();
         });

--- a/database/migrations/2019_05_16_215931_create_protocols_table.php
+++ b/database/migrations/2019_05_16_215931_create_protocols_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateProtocolsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('protocols', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name', 255);
+            $table->text('description');
+            $table->text('json_data');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('protocols');
+    }
+}

--- a/database/migrations/2019_05_16_220653_create_cameras_table.php
+++ b/database/migrations/2019_05_16_220653_create_cameras_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateCamerasTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('cameras', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id');
+            $table->string('name', 255);
+            $table->text('intrinsic');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('cameras');
+    }
+}

--- a/database/migrations/2019_05_16_221424_create_scenes_table.php
+++ b/database/migrations/2019_05_16_221424_create_scenes_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateScenesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('scenes', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id');
+            $table->bigInteger('camera_id');
+            $table->string('name', 255);
+            $table->text('transforms');
+            $table->boolean('active');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('scenes');
+    }
+}

--- a/database/migrations/2019_05_16_222259_create_three_ds_table.php
+++ b/database/migrations/2019_05_16_222259_create_three_ds_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateThreeDsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('three_ds', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id');
+            $table->string('name', 255);
+            $table->text('description');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('three_ds');
+    }
+}

--- a/database/migrations/2019_05_16_223056_create_control_definitions_table.php
+++ b/database/migrations/2019_05_16_223056_create_control_definitions_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateControlDefinitionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('control_definitions', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id');
+            $table->bigInteger('protocol_id');
+            $table->bigInteger('three_d_id');
+            $table->string('name', 255);
+            $table->text('description');
+            $table->text('json_data');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('control_definitions');
+    }
+}

--- a/database/migrations/2019_05_16_223636_create_three_d_files_table.php
+++ b/database/migrations/2019_05_16_223636_create_three_d_files_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateThreeDFilesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('three_d_files', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('three_d_id');
+            $table->string('filename', 255);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('three_d_files');
+    }
+}

--- a/database/migrations/2019_05_16_224147_create_reports_table.php
+++ b/database/migrations/2019_05_16_224147_create_reports_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateReportsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('reports', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('control_definition_id');
+            $table->string('instance_id', 255);
+            $table->text('json_data');
+            $table->boolean('active');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('reports');
+    }
+}


### PR DESCRIPTION
# This PR is to add the migrations to Toundra.

I tested it inserting data from the last backup (toundra.sql) to the schema generated for the migration, and it fit perfectly on all the tables.

Although it fit perfectly, there could be some possible issues with some general fields:

| Field             | Old Type | New Type|
| ------------- |:-------------:|:-----:|
| id    | `int(11)`| `bigint(20)` |
| Collation      | `latin1_swedish_ci`|   `utf8mb4_unicode_ci` |

## Steps to migrate
* Create a new database on phpMyAdmin
* Change the .env database configuration apunting to the new database
* Run the next command
>The next command will drop all the tables and will generate them again from scratch
```
php artisan migrate:fresh
```
Once migrated, try to dump data from phpMyAdmin like this:

```sql
INSERT INTO `cameras` (`id`, `user_id`, `name`, `intrinsic`, `created_at`, `updated_at`) VALUES
(1, 1, 'Camera de daniel', 'This is some info about camera 1', '2019-04-16 21:35:02', '2019-04-24 20:03:42'),
(9, 1, 'Camera 3', 'Some info about camera 3', '2019-04-28 01:13:15', '2019-04-28 01:13:15'),
(10, 9, 'Sony', 'Camera Sony', '2019-04-30 00:35:18', '2019-04-30 00:35:18'),
(12, 9, 'Cannon', 'Camera Cannon', '2019-04-30 00:35:39', '2019-04-30 00:35:39'),
(15, 10, 'cam1', '{}', '2019-04-30 01:11:45', '2019-04-30 01:11:45'),
(16, 11, 'camXXX_0', '{}', '2019-04-30 11:56:27', '2019-04-30 11:56:27');
```
